### PR TITLE
Auto-migrate laptimes.db to a new schema if necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ If you encounter an error message talking about sockets, understand that this to
 
 In case you modified the telemetry ip or port in *hardware_settings_config.xml*, adapt ``config.yml`` accordingly.
 
-Note: Since this is still WIP, have a look at ``migrate.sql`` to find instructions how to migrate your data when updating this tool.    
-Consider deleting your ``*.db`` files if you encounter errors, thus starting over (time tracking data is lost).  
+Unless you use the bundled version, have a look at ``migrate.sql`` to find instructions how to migrate your database for new releases.    
+If you encounter errors at start-up, see if renaming the file `dirtrally-laptimes.db` helps (which will create a new database).    
 
-Feel free to [open an issue](https://github.com/soong-construction/dirt-rally-time-recorder/issues/new).  
+In any case, feel free to [open an issue](https://github.com/soong-construction/dirt-rally-time-recorder/issues/new).  
 
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can choose to download *dirt-rally-time-recorder* as a ready-to-use bundle (
 - Install SQLite: https://www.sqlite.org/cli.html  
   - choose the ``sqlite-tools-win32-x86-XXXXXX.zip`` package
   - extract ``sqlite3.exe`` to your work folder, i.e. next to ``timerecord.py``    
-- Setup database with car and track tables with SQLite  
+- Setup database with car and track tables by running `sqlite3.exe`  
   - ``.open --new dirtrally-lb.db`` 
   - ``.read setup-dr1.sql`` (or ``setup-dr2.sql``)
 - Start time tracking  

--- a/databaseMigration.py
+++ b/databaseMigration.py
@@ -11,7 +11,7 @@ class DatabaseMigration:
         self.lapDb.execute('PRAGMA user_version = '+ str(newVersion))
         
     def expandVersion(self, versionString):
-        segments = versionString.split('.')
+        segments = versionString.strip().split('.')
         if (len(segments) != 3):
             raise RuntimeError('VERSION must match pattern X.Y.Z')
         segments = list(map(lambda s: int(s), segments))

--- a/databaseMigration.py
+++ b/databaseMigration.py
@@ -1,0 +1,36 @@
+# Steps:
+# NOTE cannot migrate dirtrally-lb.db which is either shipped OR user configured for one of the supported games
+# if user_version == 0:
+# - migrate laptimes.db as per migrate.sql, ignore errors
+# - set user_version = 2.1.0
+# for each VERSION.sql in migrate/ with user_version < VERSION
+# - run file
+# - set user_version = VERSION
+import sqlite3
+
+class DatabaseMigration:
+    
+    # TODO #15 Duplicate
+    laptimesDbName = 'dirtrally-laptimes.db'
+    laptimesDb = '/' + laptimesDbName
+    baseDb = '/dirtrally-lb.db'
+    
+    def __init__(self, approot):
+        self.approot = approot
+        self.db = None
+    
+    def setup(self):
+        try:
+            conn = sqlite3.connect(self.approot + self.baseDb)
+            db = conn.cursor()
+            self.db = db
+        except (Exception) as exc:
+            print("Error when reading from %s, please check set-up instructions in the README" % (self.baseDb))
+            raise exc
+
+    def getUserVersion(self):
+        userVersion = self.db.execute('PRAGMA user_version;').fetchall()[0][0]
+        return userVersion
+    
+    def setUserVersion(self, newVersion):
+        self.db.execute('PRAGMA user_version = '+ str(newVersion))

--- a/databaseMigration.py
+++ b/databaseMigration.py
@@ -1,36 +1,35 @@
-# Steps:
-# NOTE cannot migrate dirtrally-lb.db which is either shipped OR user configured for one of the supported games
-# if user_version == 0:
-# - migrate laptimes.db as per migrate.sql, ignore errors
-# - set user_version = 2.1.0
-# for each VERSION.sql in migrate/ with user_version < VERSION
-# - run file
-# - set user_version = VERSION
-import sqlite3
-
 class DatabaseMigration:
     
-    # TODO #15 Duplicate
-    laptimesDbName = 'dirtrally-laptimes.db'
-    laptimesDb = '/' + laptimesDbName
-    baseDb = '/dirtrally-lb.db'
+    def __init__(self, lapDb):
+        self.lapDb = lapDb
     
-    def __init__(self, approot):
-        self.approot = approot
-        self.db = None
-    
-    def setup(self):
-        try:
-            conn = sqlite3.connect(self.approot + self.baseDb)
-            db = conn.cursor()
-            self.db = db
-        except (Exception) as exc:
-            print("Error when reading from %s, please check set-up instructions in the README" % (self.baseDb))
-            raise exc
-
     def getUserVersion(self):
-        userVersion = self.db.execute('PRAGMA user_version;').fetchall()[0][0]
+        userVersion = self.lapDb.execute('PRAGMA user_version;').fetchall()[0][0]
         return userVersion
     
     def setUserVersion(self, newVersion):
-        self.db.execute('PRAGMA user_version = '+ str(newVersion))
+        self.lapDb.execute('PRAGMA user_version = '+ str(newVersion))
+        
+    def expandVersion(self, versionString):
+        segments = versionString.split('.')
+        if (len(segments) != 3):
+            raise RuntimeError('VERSION must match pattern X.Y.Z')
+        segments = list(map(lambda s: int(s), segments))
+        return segments[0] * 10**6 + segments[1] * 10**3 + segments[2]
+    
+    def migrateDb(self):
+        # Initial migration
+        self.migrate_2_2_0();
+        
+        # So far no further migrations
+    
+    def migrate_2_2_0(self):
+        self.migrate('2.2.0', lambda _: None)
+
+    def migrate(self, targetVersionString, applicator):
+        targetVersion = self.expandVersion(targetVersionString)
+        user_version = self.getUserVersion()
+        
+        if (user_version < targetVersion):
+            applicator(self.lapDb)
+            self.setUserVersion(targetVersion)

--- a/migrate.sql
+++ b/migrate.sql
@@ -1,7 +1,8 @@
 -- Follow these migration steps if you already recorded data before updating to the mentioned commits. 
 -- The ".<cmd>" instructions are for sqlite3, please adapt if you are using another SQL interface  
--- NOTE If you use the bundled version of dirt-rally-time-recorder, simply extract a newer release into your 
--- installation directory
+
+-- TODO #15 Remove migrate.sql from bundle as migration is automated
+-- NOTE If you use the bundled version of dirt-rally-time-recorder, you can skip migration of dirtrally-lb.db
 
 -- ONLY if you used this tool prior to version 1.0.0
  
@@ -18,5 +19,5 @@ ALTER TABLE laptimes ADD COLUMN timestamp INTEGER DEFAULT NULL;
 -- OR
 .read setup-dr2.sql
 
--- TODO Migration should only be necessary with a new minor version (e.g. 1.2.0), no need to refer to commit hashes.
+-- TODO #15 Migration should only be necessary with a new minor version (e.g. 1.2.0), no need to refer to commit hashes.
 -- If only dirtrally-lb.db changes, recommend migration for _every_ new version?

--- a/migrate.sql
+++ b/migrate.sql
@@ -1,10 +1,9 @@
--- The ".<cmd>" instructions are for sqlite3, please adapt if you are using another SQL interface  
+-- The ".<cmd>" instructions are to be executed with sqlite3.exe  
 
 -- Follow step A) only if you used dirt-rally-time-recorder PRIOR TO VERSION 1.0.0
 
 -- Follow step B) if you DON'T use the bundled version of dirt-rally-time-recorder (.exe). Except for patch releases 
 -- (e.g. 1.0.1, last number not 0) you should always update dirtrally-lb.db to include new cars and tracks
-
 
 -- step A)
 -- Commit 2cd7011ca0f84d3d2a4986363ac58d0bd2d65cc4

--- a/migrate.sql
+++ b/migrate.sql
@@ -1,23 +1,19 @@
--- Follow these migration steps if you already recorded data before updating to the mentioned commits. 
 -- The ".<cmd>" instructions are for sqlite3, please adapt if you are using another SQL interface  
 
--- TODO #15 Remove migrate.sql from bundle as migration is automated
--- NOTE If you use the bundled version of dirt-rally-time-recorder, you can skip migration of dirtrally-lb.db
+-- Follow step A) only if you used dirt-rally-time-recorder PRIOR TO VERSION 1.0.0
 
--- ONLY if you used this tool prior to version 1.0.0
- 
+-- Follow step B) if you DON'T use the bundled version of dirt-rally-time-recorder (.exe). Except for patch releases 
+-- (e.g. 1.0.1, last number not 0) you should always update dirtrally-lb.db to include new cars and tracks
+
+
+-- step A)
 -- Commit 2cd7011ca0f84d3d2a4986363ac58d0bd2d65cc4
 .open dirtrally-laptimes.db
 ALTER TABLE laptimes ADD COLUMN timestamp INTEGER DEFAULT NULL;
 
--- If you used this tool prior to version 2.1.0
-
--- Commit 5846c3dae24554d017a17d7e48fb3cea18d9144e
+-- step B)
 .open --new dirtrally-lb.db
 
 .read setup-dr1.sql
 -- OR
 .read setup-dr2.sql
-
--- TODO #15 Migration should only be necessary with a new minor version (e.g. 1.2.0), no need to refer to commit hashes.
--- If only dirtrally-lb.db changes, recommend migration for _every_ new version?

--- a/test_databaseMigration.py
+++ b/test_databaseMigration.py
@@ -1,0 +1,30 @@
+import unittest
+
+from databaseMigration import DatabaseMigration
+
+@unittest.skip("works only locally")
+class TestDatabase(unittest.TestCase):
+
+    def setUp(self):
+        self.thing = DatabaseMigration('test-files')
+        
+    def tearDown(self):
+        pass
+
+    def testUserVersion(self):
+        self.thing.setup()
+        userVersion = self.thing.getUserVersion()
+        self.assertEqual(userVersion, 0, "user_version not 0")
+        
+    def testSetUserVersion(self):
+        self.thing.setup()
+        self.thing.setUserVersion(100)
+        
+        userVersion = self.thing.getUserVersion()
+        self.assertEqual(userVersion, 100, "user_version not set correctly")
+        
+        self.thing.setUserVersion(0)
+
+if __name__ == "__main__":
+    #import sys;sys.argv = ['', 'TestDatabaseAccess.testUserVersion']
+    unittest.main()

--- a/test_databaseMigration.py
+++ b/test_databaseMigration.py
@@ -36,6 +36,10 @@ class TestDatabase(unittest.TestCase):
         expand_version = self.thing.expandVersion('12.1.21')
         self.assertEqual(expand_version, 12_001_021);
         
+    def testVersionExpansionWithWhitespace(self):
+        expand_version = self.thing.expandVersion(' 1.2.3\r\n')
+        self.assertEqual(expand_version, 1_002_003);
+
     def testVersionExpansionWithIllegalVersion(self):
         with self.assertRaises(RuntimeError):
             self.thing.expandVersion('1.1')

--- a/test_databaseMigration.py
+++ b/test_databaseMigration.py
@@ -1,30 +1,70 @@
 import unittest
 
 from databaseMigration import DatabaseMigration
+from unittest.mock import MagicMock
 
-@unittest.skip("works only locally")
 class TestDatabase(unittest.TestCase):
 
     def setUp(self):
-        self.thing = DatabaseMigration('test-files')
+        self.lapDb = MagicMock()
+        self.thing = DatabaseMigration(self.lapDb)
+        
+        self.cursor = MagicMock()
+        self.lapDb.execute = MagicMock(return_value=self.cursor)
+        
+        self.cursor.fetchall = MagicMock(return_value=[[0]])
         
     def tearDown(self):
         pass
 
     def testUserVersion(self):
-        self.thing.setup()
         userVersion = self.thing.getUserVersion()
         self.assertEqual(userVersion, 0, "user_version not 0")
         
     def testSetUserVersion(self):
-        self.thing.setup()
-        self.thing.setUserVersion(100)
+        initialVersion = 1_000_000
         
-        userVersion = self.thing.getUserVersion()
-        self.assertEqual(userVersion, 100, "user_version not set correctly")
+        self.thing.setUserVersion(initialVersion)
         
-        self.thing.setUserVersion(0)
+        self.assertEqual(self.lapDb.execute.call_count, 1)
+        self.lapDb.execute.assert_called_with('PRAGMA user_version = 1000000')
+        
+    def testVersionExpansion(self):
+        expand_version = self.thing.expandVersion('1.0.0')
+        self.assertEqual(expand_version, 1_000_000);
 
+        expand_version = self.thing.expandVersion('12.1.21')
+        self.assertEqual(expand_version, 12_001_021);
+        
+    def testVersionExpansionWithIllegalVersion(self):
+        with self.assertRaises(RuntimeError):
+            self.thing.expandVersion('1.1')
+
+    def testInitialMigrationFromVersion1_0_0(self):
+        initialVersion = 1_000_000
+        self.cursor.fetchall = MagicMock(return_value=[[initialVersion]])
+        
+        self.thing.migrate_2_2_0();
+
+        self.assertEqual(self.lapDb.execute.call_count, 2)
+        self.lapDb.execute.assert_called_with('PRAGMA user_version = 2002000')
+
+    def testInitialMigrationSkipped(self):
+        initialVersion = 2_002_000
+        self.cursor.fetchall = MagicMock(return_value=[[initialVersion]])
+        
+        self.thing.migrate_2_2_0();
+
+        self.lapDb.execute.assert_called_once_with('PRAGMA user_version;')
+        
+    def testAutoMigration(self):
+        initialVersion = 0
+        self.cursor.fetchall = MagicMock(return_value=[[initialVersion]])
+        
+        self.thing.migrateDb()
+        
+        self.assertGreater(self.lapDb.execute.call_count, 0)
+        
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'TestDatabaseAccess.testUserVersion']
     unittest.main()


### PR DESCRIPTION
This solves #15 and saves users a lot of hassle when updating dirt-rally-time-recorder to new releases.