### PR TITLE
Fix/track z matching

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -8,11 +8,44 @@ class TestDatabase(unittest.TestCase):
 
     def setUp(self):
         self.thing = Database('test')
+        self.thing.db = MagicMock()
 
     def tearDown(self):
         pass
 
-    def testResetStage(self):
+    def testLoadCars(self):
+        cars = [(1, 'car1')]
+        self.thing.db.fetchall = MagicMock(return_value = cars)
+
+        loadedCars = self.thing.loadCars(1000, 100, 5)
+
+        self.assertEqual(loadedCars, cars, "Did not return car")
+
+    def testIdentifyCarNoResult(self):
+        cars = []
+        self.thing.db.fetchall = MagicMock(return_value = cars)
+
+        loadedCars = self.thing.loadCars(1000, 100, 5)
+
+        self.assertEqual(loadedCars, cars, "Did not return empty result")
+
+    def testLoadTracksWithResults(self):
+        tracks = [(1, 'track1'), (2, 'track2')]
+        self.thing.db.fetchall = MagicMock(return_value = tracks)
+
+        loadedTracks = self.thing.loadTracks(10000, 10)
+
+        self.assertEqual(loadedTracks, tracks, "Did not return tracks")
+
+    def testLoadTracksWithoutResults(self):
+        tracks = []
+        self.thing.db.fetchall = MagicMock(return_value = tracks)
+
+        loadedTracks = self.thing.loadTracks(10000, 10)
+
+        self.assertEqual(loadedTracks, tracks, "Did not return empty result")
+
+    def testGetSingleCarUpdateStatements(self):
         statements = self.thing.getCarUpdateStatements(123456, [1])
 
         self.assertEqual(statements, ['UPDATE laptimes SET Car=1 WHERE Timestamp="123456";'])

--- a/tests/test_databaseAccess.py
+++ b/tests/test_databaseAccess.py
@@ -14,6 +14,13 @@ class TestDatabaseAccess(unittest.TestCase):
 
     def tearDown(self):
         pass
+    def testIdentifyTrackUnambiguous(self):
+        tracks = [(1, 'track1')]
+        self.database.loadTracks = MagicMock(return_value=tracks)
+
+        loadedTrack = self.thing.identifyTrack(10, 10000)
+
+        self.assertEqual(loadedTrack, 1, "Wrong ID")
 
     def testIdentifyTrackNoResult(self):
         tracks = []
@@ -23,59 +30,11 @@ class TestDatabaseAccess(unittest.TestCase):
 
         self.assertEqual(loadedTrack, [], "Shouldn't identify track")
 
-    def testIdentifyTrackUnambiguous(self):
-        tracks = [(1, 'track1', 10)]
-        self.database.loadTracks = MagicMock(return_value=tracks)
-
-        loadedTrack = self.thing.identifyTrack(10, 10000)
-
-        self.assertEqual(loadedTrack, 1, "Wrong ID")
-
-    def testIdentifyTrackByMatchingZValue(self):
-        tracks = [(1, 'track1', 10), (2, 'track2', 100)]
-        self.database.loadTracks = MagicMock(return_value=tracks)
-
-        loadedTrack = self.thing.identifyTrack(10, 10000)
-
-        self.assertEqual(loadedTrack, 1, "Wrong ID")
-
-    def testIdentifyTrackBySimilarZValue(self):
-        tracks = [(1, 'track1', 10), (2, 'track2', 100)]
-        self.database.loadTracks = MagicMock(return_value=tracks)
-
-        loadedTrack = self.thing.identifyTrack(70, 10000)
-
-        self.assertEqual(loadedTrack, 2, "Wrong ID")
-
-    def testCannotIdentifyTrackWithAllSimilarZValue(self):
-        tracks = [(1, 'track1', 10), (2, 'track2', 100)]
+    def testIdentifyTrackAmbiguous(self):
+        tracks = [(1, 'track1'), (2, 'track2')]
         self.database.loadTracks = MagicMock(return_value=tracks)
 
         loadedTrack = self.thing.identifyTrack(55, 10000)
-
-        self.assertEqual(loadedTrack, [1, 2], "Should return all tracks")
-
-    def testCannotIdentifyTrackWithNoSimilarZValue(self):
-        tracks = [(1, 'track1', 10), (2, 'track2', 100)]
-        self.database.loadTracks = MagicMock(return_value=tracks)
-
-        loadedTrack = self.thing.identifyTrack(-100, 10000)
-
-        self.assertEqual(loadedTrack, [1, 2], "Should return all tracks")
-        
-    def testCannotIdentifyTrackWithAllMatchingZValue(self):
-        tracks = [(1, 'track1', 100), (2, 'track2', 100)]
-        self.database.loadTracks = MagicMock(return_value=tracks)
-
-        loadedTrack = self.thing.identifyTrack(100, 10000)
-
-        self.assertEqual(loadedTrack, [1, 2], "Should return all tracks")
-
-    def testIdentifyTrackAmbiguous(self):
-        tracks = [(1, 'track1', 100), (2, 'track2', 100)]
-        self.database.loadTracks = MagicMock(return_value=tracks)
-
-        loadedTrack = self.thing.identifyTrack(10, 10000)
 
         self.assertEqual(loadedTrack, [1, 2], "Should return all tracks")
 
@@ -155,7 +114,7 @@ class TestDatabaseAccess(unittest.TestCase):
         call2 = call('UNKNOWN', 'Modern Car', 123456789, 'update200')
 
         updateHandler.assert_has_calls([call1, call2])
-        
+
     def testHandleTrackUpdatesInvokesLambda(self):
         self.database.getTrackUpdateStatements = MagicMock(return_value=['update100', 'update200'])
 

--- a/tests/test_databaseAccess.py
+++ b/tests/test_databaseAccess.py
@@ -31,7 +31,7 @@ class TestDatabaseAccess(unittest.TestCase):
 
         self.assertEqual(loadedTrack, 1, "Wrong ID")
 
-    def testIdentifyTrackByZValue(self):
+    def testIdentifyTrackByMatchingZValue(self):
         tracks = [(1, 'track1', 10), (2, 'track2', 100)]
         self.database.loadTracks = MagicMock(return_value=tracks)
 
@@ -39,7 +39,31 @@ class TestDatabaseAccess(unittest.TestCase):
 
         self.assertEqual(loadedTrack, 1, "Wrong ID")
 
-    def testCannotIdentifyTrackByZValueIfIdentical(self):
+    def testIdentifyTrackBySimilarZValue(self):
+        tracks = [(1, 'track1', 10), (2, 'track2', 100)]
+        self.database.loadTracks = MagicMock(return_value=tracks)
+
+        loadedTrack = self.thing.identifyTrack(70, 10000)
+
+        self.assertEqual(loadedTrack, 2, "Wrong ID")
+
+    def testCannotIdentifyTrackWithAllSimilarZValue(self):
+        tracks = [(1, 'track1', 10), (2, 'track2', 100)]
+        self.database.loadTracks = MagicMock(return_value=tracks)
+
+        loadedTrack = self.thing.identifyTrack(55, 10000)
+
+        self.assertEqual(loadedTrack, [1, 2], "Should return all tracks")
+
+    def testCannotIdentifyTrackWithNoSimilarZValue(self):
+        tracks = [(1, 'track1', 10), (2, 'track2', 100)]
+        self.database.loadTracks = MagicMock(return_value=tracks)
+
+        loadedTrack = self.thing.identifyTrack(-100, 10000)
+
+        self.assertEqual(loadedTrack, [1, 2], "Should return all tracks")
+        
+    def testCannotIdentifyTrackWithAllMatchingZValue(self):
         tracks = [(1, 'track1', 100), (2, 'track2', 100)]
         self.database.loadTracks = MagicMock(return_value=tracks)
 

--- a/tests/test_databaseAccess.py
+++ b/tests/test_databaseAccess.py
@@ -6,7 +6,6 @@ from timerecorder.databaseAccess import DatabaseAccess
 
 class TestDatabaseAccess(unittest.TestCase):
 
-
     def setUp(self):
         self.database = Database('test')
         self.database.recordResults = MagicMock()
@@ -14,6 +13,7 @@ class TestDatabaseAccess(unittest.TestCase):
 
     def tearDown(self):
         pass
+
     def testIdentifyTrackUnambiguous(self):
         tracks = [(1, 'track1')]
         self.database.loadTracks = MagicMock(return_value=tracks)

--- a/timerecorder/database.py
+++ b/timerecorder/database.py
@@ -81,18 +81,20 @@ class Database:
         epoch = int(time.time())
         return str(user) + str(epoch)
 
-    def loadTracks(self, tracklength):
-        self.db.execute('SELECT id, name, startz FROM Tracks WHERE abs(length - ?) < 0.001', (tracklength,))
+    def loadTracks(self, tracklength, startz):
+        select = ('SELECT id, name '
+                    'FROM Tracks '
+                    'WHERE abs(length - ?) < 0.001 AND abs(startz - ?) < 50')
+        self.db.execute(select, (tracklength, startz))
         return self.db.fetchall()
 
     def loadCars(self, idle_rpm, max_rpm, top_gear):
-        carSelectStatement = ('SELECT cars.id, cars.name '
-                              'FROM cars INNER JOIN controls USING(id) '
-                              'WHERE abs(cars.maxrpm - ?) < 1.0 AND abs(cars.idlerpm - ?) < 1.0 AND controls.topgear = ? '
-                              'ORDER BY cars.id ASC')
-        self.db.execute(carSelectStatement, (max_rpm, idle_rpm, top_gear))
-        result = self.db.fetchall()
-        return result
+        select = ('SELECT cars.id, cars.name '
+                    'FROM cars INNER JOIN controls USING(id) '
+                    'WHERE abs(cars.maxrpm - ?) < 1.0 AND abs(cars.idlerpm - ?) < 1.0 AND controls.topgear = ? '
+                    'ORDER BY cars.id ASC')
+        self.db.execute(select, (max_rpm, idle_rpm, top_gear))
+        return self.db.fetchall()
 
     def getLapDbConnection(self):
         return sqlite3.connect(self.approot + self.laptimesDb)

--- a/timerecorder/databaseAccess.py
+++ b/timerecorder/databaseAccess.py
@@ -11,8 +11,9 @@ class DatabaseAccess:
     def __init__(self, database):
         self.database = database
 
+    # TODO Identify methods are copy code
     def identifyTrack(self, z, tracklength):
-        tracks = self.database.loadTracks(tracklength)
+        tracks = self.database.loadTracks(tracklength, z)
 
         if (len(tracks) == 0):
             logger.warning("Failed to identify track")
@@ -22,27 +23,12 @@ class DatabaseAccess:
             return []
 
         elif (len(tracks) == 1):
-            index, name, startZ = tracks[0]
+            index, _ = tracks[0]
             return index
-
-        # TODO Can't abs(z - startZ) < 50 be part of the SQL query? Looks much too complicated...
-        elif (len(tracks) == 2):
-            matchingTrack = None
-            lastZ = None
-            for index, name, startZ in tracks:
-                # Cannot distinguish Pikes Peak tracks which are identical
-                tracksDiffer = lastZ != startZ
-                matchingZ = tracksDiffer and abs(z - startZ) < 50
-                matchingTrack = (index, name) if matchingZ else matchingTrack
-                lastZ = startZ
-
-            if matchingTrack and tracksDiffer:
-                index, name = matchingTrack
-                return index
 
         logger.warning("Ambiguous track data, %s matches", len(tracks))
         logger.debug("Length: %s (Z: %s)", str(tracklength), str(z))
-        return list(index for (index, _, _) in tracks)
+        return list(index for (index, _) in tracks)
 
     def identifyCar(self, max_rpm, idle_rpm, top_gear):
         cars = self.database.loadCars(idle_rpm, max_rpm, top_gear)

--- a/timerecorder/databaseAccess.py
+++ b/timerecorder/databaseAccess.py
@@ -25,7 +25,7 @@ class DatabaseAccess:
             index, name, startZ = tracks[0]
             return index
 
-        # TODO Can't Z-based recognition be part of the SQL query? Looks much too complicated...
+        # TODO Can't abs(z - startZ) < 50 be part of the SQL query? Looks much too complicated...
         elif (len(tracks) == 2):
             matchingTrack = None
             lastZ = None


### PR DESCRIPTION
Replace some overly complicated code by doing it in SQL. Removes also some restrictions in track disambiguation (e.g. more than 2 similar length tracks)